### PR TITLE
Fix typo that breaks dashboard/docs view

### DIFF
--- a/app/views/dashboard/docs.blade.php
+++ b/app/views/dashboard/docs.blade.php
@@ -34,8 +34,8 @@
 				<div class="col-md-2">
 					<select ui-select2="dateSortConfig" id="dateSortSelect" ng-model="dateSort">
 						<option value=""></option>
-						<option value="created_at">{{ trans('messages.posted')}}</option>
-						<option value="updated_at">{{ trans('messages.updated'}}</option>
+						<option value="created_at">{{ trans('messages.posted') }}</option>
+						<option value="updated_at">{{ trans('messages.updated') }}</option>
 					</select>
 				</div>
 			</div>


### PR DESCRIPTION
Error was:
'syntax error, unexpected ';'' in
/vagrant/app/storage/views/3575281d7e03dd93e83b307cbb250cc9:37

Offending code:
```html
<option value="updated_at"><?php echo trans('messages.updated'
?></option>
```