### PR TITLE
Fix 147 confirmation link

### DIFF
--- a/app/config/mail.php
+++ b/app/config/mail.php
@@ -8,7 +8,8 @@
 			'host'=> 'smtp.mailgun.org',
 			'from' => array('address' => null, 'name' => null),
 			'username' => null,
-			'password' => null
+			'password' => null,
+			'port' => 587
 		);
 	}
 
@@ -53,7 +54,7 @@ return array(
 	|
 	*/
 
-	'port' => 587,
+	'port' => $smtp_config['port'],
 
 	/*
 	|--------------------------------------------------------------------------

--- a/app/views/email/signup.blade.php
+++ b/app/views/email/signup.blade.php
@@ -6,7 +6,7 @@
 	<body>
 		<h1>{{ trans('messages.confirmationtitle') }}</h1>
 
-    <p>{{ trans('messages.confirmationaction') }}<a href="{{ url('participa/user/verify/' . $token, $parameters = array(), $secure = null) }}">{{ trans('messages.confirmationlink') }}</a></p>
+    <p>{{ trans('messages.confirmationaction') }}<a href="{{ 'http://www.gob.mx/participa/user/verify/' . $token }}">{{ trans('messages.confirmationlink') }}</a></p>
 
     {{ trans('messages.whatcanverifiedaccountsdo') }}
 


### PR DESCRIPTION

![screen shot 2015-03-02 at 8 23 29 pm](https://cloud.githubusercontent.com/assets/705860/6455547/ed837e26-c11a-11e4-95f9-ae1a476f23b6.png)

Es un parche que deja fijo el dominio en los mensajes.

Closes #147 