### PR TITLE
HOT FIX: doc links not working on home

### DIFF
--- a/public/templates/doc-list-item.html
+++ b/public/templates/doc-list-item.html
@@ -9,7 +9,7 @@
         </div>
       </div>
       <div class="col-md-9">
-        <a class="list-item-title" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}">{{ doc.title }}</a>
+        <a class="list-item-title" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}" target="_self">{{ doc.title }}</a>
       </div>
       <div class="col-md-1">
         <a class="list-item-arrow-link" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}">

--- a/public/templates/doc-list-item.html
+++ b/public/templates/doc-list-item.html
@@ -12,7 +12,7 @@
         <a class="list-item-title" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}" target="_self">{{ doc.title }}</a>
       </div>
       <div class="col-md-1">
-        <a class="list-item-arrow-link" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}">
+        <a class="list-item-arrow-link" href="/participa/docs/{{ doc.slug }}" title="{{ doc.title }}" target="_self">
           <span class="glyphicon glyphicon-chevron-right"></span>
         </a>
       </div>


### PR DESCRIPTION
Fixes #247 

Los links del home no estaban funcionando.

Un thread de SO me sugirió que usáramos `_target=self` y funcionó.

Pero la verdad no entiendo la razón del issue. **Alguien entiende este problema de Angular?**

![dawg](http://i2.kym-cdn.com/photos/images/facebook/000/234/765/b7e.jpg)
